### PR TITLE
PR: the @tmux_macros_key option is not work. The key is always F1, fix it

### DIFF
--- a/tmux-macros.tmux
+++ b/tmux-macros.tmux
@@ -4,7 +4,7 @@ current_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source $current_dir/scripts/tmux-utils.sh
 
-key=$(get_tmux_option tmux_macros_key "F1")
+key=$(get_tmux_option '@tmux_macros_key' "F1")
 
 macros_dir=$(get_tmux_option '@tmux_macros_dir' "$HOME/.tmux-macros/")
 


### PR DESCRIPTION
## issue
The tmux_macros_key configuration is not work. No metter which key is set, the key binding is always "F1".

## root cause
in file tmux-macros.tmux, the parameters when calling **get_tmux_option** is wrong. The first parmater **tmux_macros_key** is not existed and that will always cause the function returning "F1" as the key

## solution
change **tmux_macros_key** to **@tmux_macros_key**, that is the right variable name.
